### PR TITLE
Enumerate dir now for nuspec file because the file name case is undeterministic

### DIFF
--- a/NugetLightClient.cs
+++ b/NugetLightClient.cs
@@ -1054,8 +1054,9 @@ namespace Microsoft.PackageManagement.NuGetProvider
                 request.Progress(progressTracker.ProgressID, progressTracker.ConvertPercentToProgress(0.85), string.Format(CultureInfo.CurrentCulture, Messages.ReadingManifest));
 
                  //Read the package manifest and return the package object
+                var packageNameAndId = packageName + NuGetConstant.ManifestExtension;
                 var nuspec = FileUtility.GetFiles(installedFolder, "*.*", recursive: false)
-                    .FirstOrDefault(each => Path.GetFileName(each).EqualsIgnoreCase(packageName + NuGetConstant.ManifestExtension));
+                    .FirstOrDefault(each => Path.GetFileName(each).EqualsIgnoreCase(packageNameAndId));
 
                 PackageBase package = PackageUtility.ProcessNuspec(nuspec);
 

--- a/NugetLightClient.cs
+++ b/NugetLightClient.cs
@@ -1054,8 +1054,8 @@ namespace Microsoft.PackageManagement.NuGetProvider
                 request.Progress(progressTracker.ProgressID, progressTracker.ConvertPercentToProgress(0.85), string.Format(CultureInfo.CurrentCulture, Messages.ReadingManifest));
 
                  //Read the package manifest and return the package object
-                var nuspec = FileUtility.GetFiles(installedFolder, "*.nuspec", recursive: false)
-                    .FirstOrDefault(each => Path.GetFileNameWithoutExtension(each).EqualsIgnoreCase(packageName));
+                var nuspec = FileUtility.GetFiles(installedFolder, "*.*", recursive: false)
+                    .FirstOrDefault(each => Path.GetFileName(each).EqualsIgnoreCase(packageName + NuGetConstant.ManifestExtension));
 
                 PackageBase package = PackageUtility.ProcessNuspec(nuspec);
 
@@ -1067,7 +1067,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
                 };
 
                 // Delete the nuspec file
-                if (File.Exists(nuspec))
+                if (!string.IsNullOrWhiteSpace(nuspec) && File.Exists(nuspec))
                 {
                     FileUtility.DeleteFile(nuspec, false);
                 }

--- a/NugetLightClient.cs
+++ b/NugetLightClient.cs
@@ -1054,7 +1054,8 @@ namespace Microsoft.PackageManagement.NuGetProvider
                 request.Progress(progressTracker.ProgressID, progressTracker.ConvertPercentToProgress(0.85), string.Format(CultureInfo.CurrentCulture, Messages.ReadingManifest));
 
                  //Read the package manifest and return the package object
-                string nuspec = Path.Combine(installedFolder, packageName) + NuGetConstant.ManifestExtension;
+                var nuspec = FileUtility.GetFiles(installedFolder, "*.nuspec", recursive: false)
+                    .FirstOrDefault(each => Path.GetFileNameWithoutExtension(each).EqualsIgnoreCase(packageName));
 
                 PackageBase package = PackageUtility.ProcessNuspec(nuspec);
 
@@ -1066,12 +1067,9 @@ namespace Microsoft.PackageManagement.NuGetProvider
                 };
 
                 // Delete the nuspec file
-                //Get a package file path
-                var nuspecFilePath = Path.Combine(installedFolder, packageName + NuGetConstant.ManifestExtension);
-
-                if (File.Exists(nuspecFilePath))
+                if (File.Exists(nuspec))
                 {
-                    FileUtility.DeleteFile(nuspecFilePath, false);
+                    FileUtility.DeleteFile(nuspec, false);
                 }
 
                 request.Debug(Messages.DebugInfoReturnCall, "NuGetClient", "InstallPackageLocal");

--- a/NugetLightClient.cs
+++ b/NugetLightClient.cs
@@ -1054,9 +1054,9 @@ namespace Microsoft.PackageManagement.NuGetProvider
                 request.Progress(progressTracker.ProgressID, progressTracker.ConvertPercentToProgress(0.85), string.Format(CultureInfo.CurrentCulture, Messages.ReadingManifest));
 
                  //Read the package manifest and return the package object
-                var packageNameAndId = packageName + NuGetConstant.ManifestExtension;
+                var nuspecFileName = packageName + NuGetConstant.ManifestExtension;
                 var nuspec = FileUtility.GetFiles(installedFolder, "*.*", recursive: false)
-                    .FirstOrDefault(each => Path.GetFileName(each).EqualsIgnoreCase(packageNameAndId));
+                    .FirstOrDefault(each => Path.GetFileName(each).EqualsIgnoreCase(nuspecFileName));
 
                 PackageBase package = PackageUtility.ProcessNuspec(nuspec);
 

--- a/NugetLightConstant.cs
+++ b/NugetLightConstant.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
         /// <summary>
         /// Version of this provider
         /// </summary>
-        public static readonly string ProviderVersion = "2.8.5.208";
+        public static readonly string ProviderVersion = "2.8.5.209";
 
         /// <summary>
         /// Represents a method that the V2 web service supports to find a package

--- a/NugetLightProvider.csproj
+++ b/NugetLightProvider.csproj
@@ -134,6 +134,7 @@
   <ItemGroup />
   <ItemGroup>
     <None Include="35MSSharedLib1024.snk" />
+    <None Include="provider.manifest" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.8.5.208")]
-[assembly: AssemblyFileVersion("2.8.5.208")]
+[assembly: AssemblyVersion("2.8.5.209")]
+[assembly: AssemblyFileVersion("2.8.5.209")]

--- a/provider.manifest
+++ b/provider.manifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <SoftwareIdentity
     name="NuGetProvider"
-	version="2.8.5.208" versionScheme="multipartnumeric"
+	version="2.8.5.209" versionScheme="multipartnumeric"
 	media="(windows) and (PackageManagement) and (min-PackageManagement.api:2)"
 	xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd">
 


### PR DESCRIPTION
The name of nuspec file is generated, sometime upper case, sometimes lower case. This can be problem on Linux.  The case is un-deterministic .Use enumerate  directory for nuspec now to avoid it.