### PR TITLE
Update Microsoft.NETCore.App and NETStandard.Library to 2.0.0

### DIFF
--- a/NuGetProvider.csproj
+++ b/NuGetProvider.csproj
@@ -74,9 +74,9 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Update="Microsoft.NETCore.App" Version="2.0.0-preview1-002111-00" />
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.0-preview2-25401-01" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview1-25305-02" />
     <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview1-25305-02" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview1-25305-02" />


### PR DESCRIPTION
Update from preview to 2.0.0 to help fix OneGet build failure.