### PR TITLE
report final progress in MB not bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ Temporary Items
 nuget.exe
 *.nupkg
 *.nuspec_template
+/.vs/*

--- a/NugetLightClient.cs
+++ b/NugetLightClient.cs
@@ -1476,7 +1476,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
                         {
                             // report that we finished with the download
                             request.Progress(progressTracker.ProgressID, progressTracker.EndPercent,
-                                string.Format(CultureInfo.CurrentCulture, Resources.Messages.DownloadingProgress, totalDownloaded, totalBytesToReceive));
+                                string.Format(CultureInfo.CurrentCulture, Resources.Messages.DownloadingProgress, totalBytesToReceiveMB, totalBytesToReceiveMB));
 
                             request.Verbose(Messages.CompletedDownload, query);
 


### PR DESCRIPTION
Previously the last progress message would report we downloaded 1000MB when we downloaded 1000 bytes.