### PR TITLE
Fixing DefaultConfig constant

### DIFF
--- a/NugetLightRequest.cs
+++ b/NugetLightRequest.cs
@@ -85,6 +85,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
         internal const string DefaultConfig = @"<?xml version=""1.0""?>
 <configuration>
   <packageSources>
+    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
   </packageSources>
 </configuration>";
 


### PR DESCRIPTION
Fixes #65 by adding a default package source instead of none -- this is the default config that is added via nuget.exe outside of this scenario to match.